### PR TITLE
Allow Relative Paths in Env XML Files

### DIFF
--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -204,7 +204,6 @@ class MineRLEnv(gym.Env):
         with open(self.xml_file, 'r') as f:
             xml = f.read()
         # Todo: This will fail when using a remote instance manager.
-        # specifically check if missions_dir is a remote path
 
         xml = xml.replace('$(MISSIONS_DIR)', missions_dir)
 
@@ -264,6 +263,8 @@ class MineRLEnv(gym.Env):
         self.xml.find(self.ns + 'ExperimentUID').text = self.exp_uid
         fileworld_path = self.xml.find( './/' + self.ns + 'FileWorldGenerator').attrib['src']
         if not os.path.isabs(fileworld_path):
+            # If the path for the FileWorldGenerator is a relative path,
+            # assume it to be relative to the xml file itself
             xml_directory = os.path.dirname(self.xml_file)
             new_fileworld_path = os.path.join(xml_directory, fileworld_path)
             self.xml.find('.//' + self.ns + 'FileWorldGenerator').attrib['src'] = new_fileworld_path

--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -204,6 +204,8 @@ class MineRLEnv(gym.Env):
         with open(self.xml_file, 'r') as f:
             xml = f.read()
         # Todo: This will fail when using a remote instance manager.
+        # specifically check if missions_dir is a remote path
+
         xml = xml.replace('$(MISSIONS_DIR)', missions_dir)
 
         if self.spec is not None:
@@ -260,6 +262,11 @@ class MineRLEnv(gym.Env):
         self.xml = e
         self.xml.find(self.ns + 'ClientRole').text = str(self.role)
         self.xml.find(self.ns + 'ExperimentUID').text = self.exp_uid
+        fileworld_path = self.xml.find( './/' + self.ns + 'FileWorldGenerator').attrib['src']
+        if not os.path.isabs(fileworld_path):
+            xml_directory = os.path.dirname(self.xml_file)
+            new_fileworld_path = os.path.join(xml_directory, fileworld_path)
+            self.xml.find('.//' + self.ns + 'FileWorldGenerator').attrib['src'] = new_fileworld_path
         if self.role != 0 and self.agent_count > 1:
             e = etree.Element(self.ns + 'MinecraftServerConnection',
                               attrib={'address': self.instance.host,


### PR DESCRIPTION
Dynamically check whether a FIleWorldGenerator path is relative or absolute, and if it's relative, operate under the assumption that the file is in the same directory where the xml is itself located. 