### PR TITLE
Fix multiprocess port allocation race condition

### DIFF
--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -698,9 +698,14 @@ class MineRLEnv(gym.Env):
         for line in lines:
             print(line)
 
-    def log_shows_bind_exception(self, num_lines=10):
+    def log_shows_bind_exception(self, num_lines=10, verbose=True):
         error_msg = 'java.net.BindException'
-        return any(error_msg in line for line in self._get_logs(num_lines))
+        for line in self._get_logs(num_lines):
+            if error_msg in line:
+                if verbose:
+                    print(f"Detected BindException (!): {line}")
+                return True
+        return False
 
     def _get_logs(self, num_lines=5):
         if not (self.instance and self.instance.minecraft_dir):

--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -712,6 +712,10 @@ class MineRLEnv(gym.Env):
         return tail(log_file, lines=num_lines)
 
 
+def make():
+    return Env()
+
+
 def register(id, **kwargs):
     # TODO create doc string based on registered envs
     return gym.envs.register(id, **kwargs)

--- a/minerl/env/malmo.py
+++ b/minerl/env/malmo.py
@@ -46,7 +46,7 @@ import psutil
 import Pyro4
 
 
-from random import Random
+import random
 from minerl.env import comms
 
 logger = logging.getLogger(__name__)
@@ -70,6 +70,11 @@ MAXRAND = 1000000
 
 INSTANCE_MANAGER_PYRO = 'minerl.instance_manager'
 MINERL_INSTANCE_MANAGER_REMOTE = 'MINERL_INSTANCE_MANAGER_REMOTE'
+
+# Unix empheral ports actually start lower, but the IANA standards are compatible
+# with Windows too.
+IANA_DYNAMIC_PORT_LOW = 49152
+IANA_DYNAMIC_PORT_HIGH = 65536
 
 @Pyro4.expose
 @Pyro4.behavior(instance_mode="single")
@@ -118,7 +123,7 @@ class InstanceManager:
             cls._seed_generator = seeds
         elif seed_type == SeedType.GENERATED:
             assert seeds is not None, "Seed set to generated seed, so initial seed must be specified."
-            cls._seed_generator = Random(seeds[0])
+            cls._seed_generator = random.Random(seeds[0])
         else:
             raise TypeError("Seed type {} not supported".format(seed_type))
         
@@ -260,29 +265,28 @@ class InstanceManager:
             ports = [x.laddr.port for x  in psutil.net_connections()]
             return port in ports
 
-    @staticmethod
-    def _is_display_port_taken(port, x11_path):
-        return False
-
     @classmethod
     def _port_in_instance_pool(cls, port):
         # Ideally, this should be covered by other cases, but there may be delay
         # in when the ports get "used"
+
+        # shwang: Unfortunately, this check doesn't account for the multiprocess
+        # case where there are several instance pools. We leave it here despite
+        # this because it is a quick way to avoid expensively launching a
+        # second instance on the same port.
         return port in [instance.port for instance in cls._instance_pool]
 
     @classmethod
-    def configure_malmo_base_port(cls, malmo_base_port):
-        """Configure the lowest or base port for Malmo"""
-        cls._malmo_base_port = malmo_base_port
-
-    @classmethod
     def _get_valid_port(cls):
-        malmo_base_port = cls._malmo_base_port
-        port = (cls.ninstances  % 5000) + malmo_base_port
-        while cls._is_port_taken(port) or \
-              cls._is_display_port_taken(port - malmo_base_port, cls.X11_DIR) or \
-              cls._port_in_instance_pool(port):
-            port += 1
+        return 9005
+        port = random.randrange(IANA_DYNAMIC_PORT_LOW, IANA_DYNAMIC_PORT_HIGH)
+        while cls._is_port_taken(port) or cls._port_in_instance_pool(port):
+            # TODO(shwang): I removed a reference to is_display_port_taken here.
+            # I'll make sure to explain why on my PR.
+            
+            # I don't know how to tell if a process needs to retry. If that happens,
+            # I'll just take the L, I guess.
+            port = random.randrange(IANA_DYNAMIC_PORT_LOW, IANA_DYNAMIC_PORT_HIGH)
         return port
 
 


### PR DESCRIPTION
We run into a race condition when multiple processes launch MineRL environments from different InstanceManagers, and different Minecraft instances are instructed to bind to the same port.

While connecting to Minecraft, MineRLEnv now looks for `BindException` inside the Minecraft process's logs (indicating a port collision) and immediately relaunch a new Minecraft instance with a different port when this happens. This allows us to recover from the race condition, but is expensive because launching a Minecraft instance takes time.

The InstanceManager port allocation scheme now chooses randomly from unbound ephemeral ports instead of linearly searching through (9000, 9001, ...). This reduces the chance of a race condition arising.

Other changes:
* Removed `InstanceManager._malmo_base_port`. This used to be used primarily as a starting point for linearly searching for available ports. Since we randomly allocate now this isn't necessary.
* Removed `InstanceManager.is_display_port()`, as it always returned False and depended on `InstanceManager._malmo_base_port`.