### PR TITLE
Retry InstanceManager launch on Gradle error

### DIFF
--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -161,15 +161,8 @@ class MineRLEnv(gym.Env):
             instance = None
         return instance
 
-    def _robust_launch_new_instance(self, *, max_tries=1) -> InstanceManager:
-        """
-        Gets a new instance and sets up a logger if need be. 
-        """
-        # Explain why I got rid of port option here.
-        # 1. The port option was actually broken (NameError)
-        # 2. We don't ever use the port and nothing seems to reference this.
-        # 3. If we need it in the future we can add it back in.
-        # 4. Not sure what the use case for this is.
+    def _robust_launch_new_instance(self, *, max_tries=3) -> InstanceManager:
+        """Launch and return a new InstanceManager. Attempt up to `max_tries` times."""
         for i in range(max_tries):
             instance = self._attempt_launch_new_instance()
             if instance is not None:

--- a/minerl/env/malmo.py
+++ b/minerl/env/malmo.py
@@ -228,7 +228,7 @@ class InstanceManager:
     @classmethod
     def add_existing_instance(cls, port):
         # shwang: This function is never used by MineRL. You can tell because
-        # status_dir would NameError on the `instance = InstaceManager` line.
+        # status_dir would NameError on the `instance = InstanceManager` line.
         assert cls._is_port_taken(port), "No Malmo mod utilizing the port specified."
         instance = InstanceManager.Instance(port=port, existing=True, status_dir=status_dir)
         cls._instance_pool.append(instance)


### PR DESCRIPTION
This PR addresses an intermittent Gradle build error that sometimes arises when I launch several MineRL environments in parallel, probably due to a race condition that is beyond my Java+Gradle knowledge. (One step in initializing a MineRL env is using a Gradle build script to make a custom mod of Minecraft.)

Before this PR, the build error led to an uncaught `EOFError` from InstanceManager which would terminate the entire training process. After this PR, the build error raises a `malmo.IntermittentBuildError` which is excepted by MineRL Envup to `max_tries=3` times before it gives up and terminating the process. Common setup errors (eg "Can't find display window") are not excepted.

I also removed some code paths unused by MineRL (probably left over from copying a Malmo python file) to make my logic simpler.
* `_get_new_instance(self, port=None)` accepted an optional port argument that would make Malmo not actually get a "new" new instance, but instead get an old-new instance associated with a previously launched Malmo environment on that port. This code path was never used and had at least one bug (I found a NameError).
* Other unused code paths I either left a comment indicating that they were unused (for future reference) or deleted if they seemed really minor.

Finally, I moved `self.running = True` from the end of `InstanceManager.launch()` to right after the line where the minecraft build process starts running (this is what `self.running` is supposed to indicate). This is important because otherwise the build error could exit the function before `self.running = True` is set, and then `InstanceManager.kill()` becomes a no-op.