### PR TITLE
Picklable action spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ done = False
 while not done:
     action = env.action_space.sample() 
  
-    # One can also take a no_op action with
-    # action =env.action_space.noop()
+    # One can also take a no-op action with
+    # action = env.action_space.noop()
     
  
     obs, reward, done, info = env.step(

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -17,7 +17,7 @@ environment!
     be evaluated in :code:`MineRLObtainDiamond-v0` which has **sparse** rewards. See `MineRLObtainDiamond-v0`_.
 
 .. note::
-    All environments offer a default no-op action via :code:`env.action_space.no_op()`
+    All environments offer a default no-op action via :code:`env.action_space.noop()`
     and a random action via :code:`env.action_space.sample()`
 
 .. include:: handlers.rst

--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -174,6 +174,8 @@ class MineRLEnv(gym.Env):
                 return np.zeros(shape=space.shape, dtype=space.dtype)
             else:
                 try:
+                    # TODO(shwang): Confirmed -- no one uses space.default()
+                    # Nothing popped up after searches for "def default" and ".default".
                     return space.default()
                 except NameError:
                     raise ValueError('Specify non-None default_action in gym.register or extend all '
@@ -182,11 +184,16 @@ class MineRLEnv(gym.Env):
             self._default_action = {key: map_space(
                 space) for key, space in action_space.spaces.items()}
 
+        # TODO(shwang): AFAICT, .noop is .no_op but reimplemented with closures,
+        # and with a cached return value.
+
         def noop_func(a):
             return deepcopy(self._default_action)
 
-        boundmethd = _bind(self.action_space, noop_func)
-        self.action_space.noop = boundmethd
+        # TODO(shwang): Confirmed -- no one uses noop_func.
+        # boundmethd = _bind(self.action_space, noop_func)
+        # Unused!
+        # self.action_space.noop = boundmethd
 
     def init(self):
         """Initializes the MineRL Environment.
@@ -301,7 +308,10 @@ class MineRLEnv(gym.Env):
         Returns:
             Any: A no-op action in the env's space.
         """
-        return deepcopy(self._default_action)
+        # TODO(shwang): I'm a bit confused about why the code has 3 different
+        # ways to access the no_op action for action space, with at least 2
+        # duplicate implementations.
+        return self.action_space.noop()
 
     def _process_observation(self, pov, info):
         """

--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -96,7 +96,6 @@ class MineRLEnv(gym.Env):
             observation_space (gym.Space): The observation for the environment.
             action_space (gym.Space): The action space for the environment.
             port (int, optional): The port of an exisitng Malmo environment. Defaults to None.
-            noop_action (Any, optional): The no-op action for the environment. This must be in the action_space. Defaults to None.
         """
     metadata = {'render.modes': ['rgb_array', 'human']}
 
@@ -108,13 +107,12 @@ class MineRLEnv(gym.Env):
     }
 
     def __init__(self, xml, observation_space, action_space, port=None,
-                 noop_action=None, docstr=None, obs_handlers=None):
-        self.action_space = None
-        self.observation_space = None
+                 docstr=None, obs_handlers=None):
+        self.action_space = action_space
+        self.observation_space = observation_space
         self.obs_handlers = deepcopy(self.DEFAULT_OBS_HANDLERS)
         if obs_handlers is not None:
             self.obs_handlers.update(obs_handlers)
-        self._default_action = noop_action
 
         self.viewer = None
 
@@ -142,8 +140,6 @@ class MineRLEnv(gym.Env):
         self._already_closed = False
         self.instance = self._get_new_instance(port)
 
-        self._setup_spaces(observation_space, action_space)
-
         self.resets = 0
         self.done = True
 
@@ -162,38 +158,6 @@ class MineRLEnv(gym.Env):
         
         instance.launch()
         return instance
-
-    def _setup_spaces(self, observation_space, action_space):
-        self.action_space = action_space
-        self.observation_space = observation_space
-
-        def map_space(space):
-            if isinstance(space, gym.spaces.Discrete) or isinstance(space, minerl.env.spaces.Enum):
-                return 0
-            elif isinstance(space, gym.spaces.Box):
-                return np.zeros(shape=space.shape, dtype=space.dtype)
-            else:
-                try:
-                    # TODO(shwang): Confirmed -- no one uses space.default()
-                    # Nothing popped up after searches for "def default" and ".default".
-                    return space.default()
-                except NameError:
-                    raise ValueError('Specify non-None default_action in gym.register or extend all '
-                                     'action spaces with default() method')
-        if self._default_action is None:
-            self._default_action = {key: map_space(
-                space) for key, space in action_space.spaces.items()}
-
-        # TODO(shwang): AFAICT, .noop is .no_op but reimplemented with closures,
-        # and with a cached return value.
-
-        def noop_func(a):
-            return deepcopy(self._default_action)
-
-        # TODO(shwang): Confirmed -- no one uses noop_func.
-        # boundmethd = _bind(self.action_space, noop_func)
-        # Unused!
-        # self.action_space.noop = boundmethd
 
     def init(self):
         """Initializes the MineRL Environment.
@@ -296,22 +260,6 @@ class MineRLEnv(gym.Env):
         # print(etree.tostring(self.xml))
 
         self.has_init = True
-
-    def noop_action(self):
-        """Gets the no-op action for the environment.
-
-        In addition one can get the no-op/default action directly from the action space.
-
-            env.action_space.noop()
-
-
-        Returns:
-            Any: A no-op action in the env's space.
-        """
-        # TODO(shwang): I'm a bit confused about why the code has 3 different
-        # ways to access the no_op action for action space, with at least 2
-        # duplicate implementations.
-        return self.action_space.noop()
 
     def _process_observation(self, pov, info):
         """

--- a/minerl/env/spaces.py
+++ b/minerl/env/spaces.py
@@ -39,7 +39,7 @@ class Enum(gym.spaces.Discrete):
         """
         return super().sample()
 
-    def no_op(self) -> int:
+    def noop(self) -> int:
         return 0
 
     def __getitem__(self, action):
@@ -62,21 +62,21 @@ class Enum(gym.spaces.Discrete):
 
 
 class Box(gym.spaces.Box):
-    def no_op(self):
+    def noop(self):
         return np.zeros(shape=self.shape).astype(self.dtype)
 
 
 class Dict(gym.spaces.Dict):
-    def no_op(self):
-        return OrderedDict([(k, space.no_op()) for k, space in self.spaces.items()])
+    def noop(self):
+        return OrderedDict([(k, space.noop()) for k, space in self.spaces.items()])
 
 
 class Discrete(gym.spaces.Discrete):
-    def no_op(self):
+    def noop(self):
         return 0
 
 
 class MultiDiscrete(gym.spaces.MultiDiscrete):
-    def no_op(self):
+    def noop(self):
         return (np.zeros(self.nvec.shape)*self.nvec).astype(self.dtype)
 

--- a/tests/local/handler_test.py
+++ b/tests/local/handler_test.py
@@ -11,7 +11,7 @@ def gen_obtain_debug_actions(env):
     actions = []
 
     def act(**kwargs):
-        action = env.action_space.no_op()
+        action = env.action_space.noop()
         for key, value in kwargs.items():
             action[key] = value
         actions.append(action)
@@ -91,7 +91,7 @@ def test_env(environment='MineRLObtainTest-v0'):
                 break
 
         while not done:
-            obs, reward, done, info = env.step(env.action_space.no_op())
+            obs, reward, done, info = env.step(env.action_space.noop())
             if reward != 0:
                 print(reward)
         print("MISSION DONE")


### PR DESCRIPTION
Before this PR, any `MineRLEnv.action_space` was unpicklable, causing errors when saving some Stable Baselines policies. The unpicklablilty was due to `MineRLEnv.action_space.noop` closing over the `MineRLEnv` instance (which we wouldn't reasonably expect to be serializable).

AFAICT `action_space.noop`, which is dynamically added to MineRLEnv.action_space upon initialization of MineRLEnv, is functionally identical (except in one case) to `action_space.no_op`, which unlike `noop` is picklable because it doesn't close over the entire Env.

The one case in which `noop` is different from `no_op` is when `MineRLEnv.__init__(...)` receives an optional `noop_action` argument, in which case `noop` always returns that argument. It doesn't look like any code path sets the `noop_action` argument (from searching "noop_action").

There's also a third way to access the no-op action: the `MineRLEnv.noop_action(self)` method.

After this PR, the only way to access the no-op action is the allow-action-spaces-to-be-picklable variant, which I have renamed from `no_op()` to `noop()` because the MineRL docs and code most often uses `noop()` instead of `no_op()`. I've found and replaced references to `no_op()` and `noop_action()`.

I also deleted the `MineRLEnv.__init__` method's `noop_action` argument and related code, as it is now unused and I think it's unlikely that we will want custom no_op actions. (I don't think it would be hard to get the `noop_action` feature this working and picklable right now if anyone objects to this removal.)