### PR TITLE
Fix DataPipeline ProcessingPool leak

### DIFF
--- a/minerl/data/data_pipeline.py
+++ b/minerl/data/data_pipeline.py
@@ -55,7 +55,6 @@ class DataPipeline:
         self.number_of_workers = num_workers
         self.worker_batch_size = worker_batch_size
         self.size_to_dequeue = min_size_to_dequeue
-        self.processing_pool = multiprocessing.Pool(self.number_of_workers)
 
         self._action_space = gym.envs.registration.spec(self.environment)._kwargs['action_space']
         self._observation_space = gym.envs.registration.spec(self.environment)._kwargs['observation_space']
@@ -179,37 +178,38 @@ class DataPipeline:
             # for arg1, arg2, arg3 in files:
             #     DataPipeline._load_data_pyfunc(arg1, arg2, arg3)
             #     break
-            map_promise = self.processing_pool.starmap_async(DataPipeline._load_data_pyfunc, files, error_callback=None)
+            with multiprocessing.Pool(self.number_of_workers) as pool:
+                map_promise = pool.starmap_async(DataPipeline._load_data_pyfunc, files, error_callback=None)
 
-            # random_queue = PriorityQueue(maxsize=pool_size)
+                # random_queue = PriorityQueue(maxsize=pool_size)
 
-            # We map the files -> load_data -> batch_pool -> random shuffle -> yield.
-            while True:
-                try:
-                    sequence = data_queue.get_nowait()
-                    if include_metadata:
-                        observation_seq, action_seq, reward_seq, next_observation_seq, done_seq, meta = sequence
-                    else:
-                        observation_seq, action_seq, reward_seq, next_observation_seq, done_seq = sequence
+                # We map the files -> load_data -> batch_pool -> random shuffle -> yield.
+                while True:
+                    try:
+                        sequence = data_queue.get_nowait()
+                        if include_metadata:
+                            observation_seq, action_seq, reward_seq, next_observation_seq, done_seq, meta = sequence
+                        else:
+                            observation_seq, action_seq, reward_seq, next_observation_seq, done_seq = sequence
 
-                    # Wrap in dict
-                    gym_spec = gym.envs.registration.spec(self.environment)
+                        # Wrap in dict
+                        gym_spec = gym.envs.registration.spec(self.environment)
 
-                    observation_dict = DataPipeline.map_to_dict(observation_seq, gym_spec._kwargs['observation_space'])
-                    action_dict = DataPipeline.map_to_dict(action_seq, gym_spec._kwargs['action_space'])
-                    next_observation_dict = DataPipeline.map_to_dict(next_observation_seq, gym_spec._kwargs['observation_space'])
-                    
-                    if include_metadata:
-                        yield observation_dict, action_dict, reward_seq[0], next_observation_dict, done_seq[0], meta
-                    else:
-                        yield observation_dict, action_dict, reward_seq[0], next_observation_dict, done_seq[0]
-                
-                except Empty:
-                    if map_promise.ready():
-                        epoch += 1
-                        break
-                    else:
-                        time.sleep(0.1)
+                        observation_dict = DataPipeline.map_to_dict(observation_seq, gym_spec._kwargs['observation_space'])
+                        action_dict = DataPipeline.map_to_dict(action_seq, gym_spec._kwargs['action_space'])
+                        next_observation_dict = DataPipeline.map_to_dict(next_observation_seq, gym_spec._kwargs['observation_space'])
+
+                        if include_metadata:
+                            yield observation_dict, action_dict, reward_seq[0], next_observation_dict, done_seq[0], meta
+                        else:
+                            yield observation_dict, action_dict, reward_seq[0], next_observation_dict, done_seq[0]
+
+                    except Empty:
+                        if map_promise.ready():
+                            epoch += 1
+                            break
+                        else:
+                            time.sleep(0.1)
         logger.debug("Epoch complete.")
 
     def load_data(self, stream_name: str, skip_interval=0, include_metadata=False):

--- a/minerl/util.py
+++ b/minerl/util.py
@@ -1,0 +1,7 @@
+import psutil
+
+
+def child_count() -> int:
+    current_process = psutil.Process()
+    children = current_process.children()
+    return len(children)

--- a/tests/data_ordering_test.py
+++ b/tests/data_ordering_test.py
@@ -73,7 +73,7 @@ def _child_count() -> int:
 def test_data_pipeline_leak(enter_generator, max_allowed_procs_increase=20):
     starting_procs = _child_count()
     for n_gen in range(5):
-        data = minerl.data.make('MineRLNavigate-v0', data_dir="demonstrations")
+        data = minerl.data.make('MineRLNavigate-v0')
 
         if enter_generator:
             generator = data.sarsd_iter()

--- a/tests/data_ordering_test.py
+++ b/tests/data_ordering_test.py
@@ -1,6 +1,7 @@
 import time
 
 import minerl
+from minerl import util
 import itertools
 import gym
 import sys
@@ -63,15 +64,9 @@ def _check_space(key, space, observation, correct_len):
         assert False, "Unsupported dict type"
 
 
-def _child_count() -> int:
-    current_process = psutil.Process()
-    children = current_process.children()
-    return len(children)
-
-
 @pytest.mark.parametrize("enter_generator", [False, True])
 def test_data_pipeline_leak(enter_generator, max_allowed_procs_increase=20):
-    starting_procs = _child_count()
+    starting_procs = util.child_count()
     for n_gen in range(5):
         data = minerl.data.make('MineRLNavigate-v0')
 
@@ -81,8 +76,8 @@ def test_data_pipeline_leak(enter_generator, max_allowed_procs_increase=20):
 
         print()
         print(f"Building the {n_gen}th DataPipeline.")
-        print(f"We now have {_child_count()} child processes.")
-        assert _child_count() - starting_procs <= max_allowed_procs_increase
+        print(f"We now have {util.child_count()} child processes.")
+        assert util.child_count() - starting_procs <= max_allowed_procs_increase
 
 
 


### PR DESCRIPTION
Use `multiprocessing.ProcessPool` context to fix memory leak and add a couple of Travis CI-compatible tests to check for this failure.

I confirmed that the tests fail on my machine before the fix.