### PR TITLE
Fix incorrect reference to self.action_space in process_action

### DIFF
--- a/minerl/env/core.py
+++ b/minerl/env/core.py
@@ -434,7 +434,7 @@ class MineRLEnv(gym.Env):
                 else:
                     assert isinstance(
                         action_in[act], str), "Enum action {} must be str or int. Value observed: {} ".format(act, action_in[act])
-                    assert action_in[act] in self.action_space.spaces[act].values, \
+                    assert action_in[act] in bottom_env_spec.action_space.spaces[act].values, \
                         "Invalid string value for enum action {}, {}".format(act, action_in[act])
             elif isinstance(bottom_env_spec.action_space.spaces[act], gym.spaces.Box):
                 subact = action_in[act]


### PR DESCRIPTION
Per Slack convo with @shwang , modified `env.core.py` to reference `bottom_env_spec` rather than `self.action_space` when checking elements of unwrapped (i.e. un-obfuscated action). If you check against `self.action_space` for an obfuscated environment, that will mean checking keys of the unwrapped dict against the wrapped/obfuscated action space. 

This came up while trying to debug tests on `il_representations`, and this will need to be merged into CHAI MineRL master before those tests will pass

[Also, possibly I should try to merge this into MineRL itself? Since it seems like it would also be an issue for them...] 